### PR TITLE
Corrected log_events service field style

### DIFF
--- a/custom_components/edgeos/services.yaml
+++ b/custom_components/edgeos/services.yaml
@@ -10,4 +10,9 @@ save_debug_data:
 log_events:
   description: "Enable / Disable log of all event messages from WebSocket (DEBUG)"
   fields:
-    enabled: "True / False - whether to log as DEBUG all events"
+    enabled:
+      description: "True / False - whether to log as DEBUG all events"
+      example: "true"
+      values:
+        - true
+        - false


### PR DESCRIPTION
The log_events service does not conform with the field styling of Home Assistant services.  See here: https://developers.home-assistant.io/docs/en/dev_101_services.html#service-descriptions