### PR TITLE
Updates docs re: DPI and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Please install in HACS, look for "Integration with EdgeOS (Ubiquiti)"
 
 #### Requirements
 * EdgeRouter User with 'Operator' level access or higher
-* Traffic Analysis set to 'Hosts only' or 'Enabled'
+* Traffic Analysis set to 'Enabled' (both `dpi` and `export` enabled under `system/traffic-analysis`)
 
 #### Basic configuration
 * Configuration should be done via Configuration -> Integrations.
-* In case you are already using that integration with YAML Configuration - please removed it
+* In case you are already using that integration with YAML Configuration - please remove it
 * Integration supports **multiple** devices 
 * In the setup form, the following details are mandatory:
   * Name - Unique
@@ -26,8 +26,8 @@ Please install in HACS, look for "Integration with EdgeOS (Ubiquiti)"
   * Invalid credentials (403)
   * General authentication error (when failed to get valid response from device)
   * Could not retrieve device data from EdgeOS Router
-  * Export configuration is disabled, please enable
-  * Deep Packet Investigation configuration is disabled, please enable
+  * Export (traffic-analysis) configuration is disabled, please enable
+  * Deep Packet Inspection (traffic-analysis) configuration is disabled, please enable
 
 #### Monitoring interfaces, devices and track devices
 *Configuration -> Integrations -> {Integration} -> Options* <br />

--- a/custom_components/edgeos/.translations/en.json
+++ b/custom_components/edgeos/.translations/en.json
@@ -20,9 +20,9 @@
     "error": {
       "invalid_credentials": "Invalid credentials to EdgeOS Router",
       "auth_general_error": "General failure, please try again",
-      "not_found": "EdgeOS Url not found",
-      "invalid_export_configuration": "Export configuration is disabled, please enable",
-      "invalid_dpi_configuration": "Deep Packet Investigation configuration is disabled, please enable",
+      "not_found": "EdgeOS URL not found",
+      "invalid_export_configuration": "Export (traffic-analysis) configuration is disabled, please enable",
+      "invalid_dpi_configuration": "Deep Packet Inspection (traffic-analysis) configuration is disabled, please enable",
       "empty_device_data": "Could not retrieve device data from EdgeOS Router"
     }
   },

--- a/custom_components/edgeos/config_flow.py
+++ b/custom_components/edgeos/config_flow.py
@@ -63,13 +63,13 @@ class EdgeOSConfigValidation:
                     error_prefix = f"Invalid EdgeOS ({name}) configuration -"
 
                     if dpi != "enable":
-                        _LOGGER.warning(f"{error_prefix} Deep packet investigation (DPI) is disabled")
+                        _LOGGER.warning(f"{error_prefix} Deep Packet Inspection (DPI) is disabled")
                         errors = {
                             "base": "invalid_dpi_configuration"
                         }
 
                     if export != "enable":
-                        _LOGGER.warning(f"{error_prefix} Export is disabled")
+                        _LOGGER.warning(f"{error_prefix} Traffic Analysis Export is disabled")
                         errors = {
                             "base": "invalid_export_configuration"
                         }

--- a/custom_components/edgeos/strings.json
+++ b/custom_components/edgeos/strings.json
@@ -20,9 +20,9 @@
     "error": {
       "invalid_credentials": "Invalid credentials to EdgeOS Router",
       "auth_general_error": "General failure, please try again",
-      "not_found": "EdgeOS Url not found",
-      "invalid_export_configuration": "Export configuration is disabled, please enable",
-      "invalid_dpi_configuration": "Deep Packet Investigation configuration is disabled, please enable",
+      "not_found": "EdgeOS URL not found",
+      "invalid_export_configuration": "Export (traffic-analysis) configuration is disabled, please enable",
+      "invalid_dpi_configuration": "Deep Packet Inspection (traffic-analysis) configuration is disabled, please enable",
       "empty_device_data": "Could not retrieve device data from EdgeOS Router"
     }
   },

--- a/info.md
+++ b/info.md
@@ -9,11 +9,11 @@ Please install in HACS, look for "Integration with EdgeOS (Ubiquiti)"
 
 #### Requirements
 * EdgeRouter User with 'Operator' level access or higher
-* Traffic Analysis set to 'Hosts only' or 'Enabled'
+* Traffic Analysis set to 'Enabled' (both `dpi` and `export` enabled under `system/traffic-analysis`)
 
 #### Basic configuration
 * Configuration should be done via Configuration -> Integrations.
-* In case you are already using that integration with YAML Configuration - please removed it
+* In case you are already using that integration with YAML Configuration - please remove it
 * Integration supports **multiple** devices 
 * In the setup form, the following details are mandatory:
   * Name - Unique
@@ -26,8 +26,8 @@ Please install in HACS, look for "Integration with EdgeOS (Ubiquiti)"
   * Invalid credentials (403)
   * General authentication error (when failed to get valid response from device)
   * Could not retrieve device data from EdgeOS Router
-  * Export configuration is disabled, please enable
-  * Deep Packet Investigation configuration is disabled, please enable
+  * Export (traffic-analysis) configuration is disabled, please enable
+  * Deep Packet Inspection (traffic-analysis) configuration is disabled, please enable
 
 #### Monitoring interfaces, devices and track devices
 *Configuration -> Integrations -> {Integration} -> Options* <br />


### PR DESCRIPTION
Hi there!

Thanks for your work on this 👍 

The PR here is purely doc/error message related:
* The "I" in DPI is "Inspection"
* "URL" should be capitalised
* Adds hints to the error messages that the configuration is under `traffic-analysis`
* More clarity that "Export" relates to the traffic-analysis config (this took a bit of Googling when it initially didn't work for me)
* Currently `dpi` is "required", thus remove "Hosts only"  from the requirements (it must be enabled)

===

(Unrelated to PR)

* It appears the HACS is not yet live per your PR https://github.com/hacs/default/pull/319 (manually adding `elad-bar/ha-edgeos` worked though). Depending on their timeline for reviewing, it might be worth adding a note in the README about this?

===

Technically, it doesn't appear `dpi` is _actually_ required, though the configure fails without it:

https://github.com/elad-bar/ha-edgeos/blob/bf90960e2483db22f5960b6b6e97a47c3ffbd0c3/custom_components/edgeos/config_flow.py#L65-L69


The logic here doesn't appear to use the application name, thus `dpi` can be disabled (?) - it's just summing the values etc.:

https://github.com/elad-bar/ha-edgeos/blob/3961baeacfbf5edd8073b9ed1d8b8218395a7cf9/custom_components/edgeos/EdgeOSData.py#L422-L437

For reference, here is the sats with `export` enabled and `dpi` disabled (eg. "Host only"):
``` json
{
    "export": {
        "192.168.1.2": {
            "Other|Other": {
                "tx_bytes": "3328",
                "tx_rate": "0",
                "rx_bytes": "0",
                "rx_rate": "0"
            }
        },
        "192.168.1.3": {
            "Other|Other": {
                "tx_bytes": "1367",
                "tx_rate": "20",
                "rx_bytes": "773",
                "rx_rate": "20"
            }
        },
        "192.168.1.4": {
            "Other|Other": {
                "tx_bytes": "2341",
                "tx_rate": "69",
                "rx_bytes": "1673",
                "rx_rate": "56"
            }
        }
    }
}
```