### PR TITLE
Bugfix: Update state immediately according to service data

### DIFF
--- a/custom_components/edgeos/managers/data_manager.py
+++ b/custom_components/edgeos/managers/data_manager.py
@@ -515,7 +515,7 @@ class EdgeOSData:
                             if item in service_data and service_data[item] != "":
                                 service_data_item_value = int(service_data[item])
 
-                            if "x_rate" in item and current_value > 0:
+                            if "x_rate" in item and service_data_item_value > 0:
                                 device[LAST_ACTIVITY] = datetime.now()
 
                             traffic_value = current_value + service_data_item_value


### PR DESCRIPTION
This bugfix is to solve issue #32.
I've found that the `Last Activity` attribute is only updated on the second time that activity has been received from EdgeOS.
When the first activity is received the `traffic` dictionary is updated, but the `Last Activity` attribute isn't updated until more activity has been received.
It seems that the second update has to occur very closely to the first update, or perhaps even on the same message from EdgeOS in order for the `Last Activity` to get updated.

This has caused an issue where some devices appear as "Disconnected" forever, even though they are well connected (because when the `Last Activity` attribute isn't updated - devices remain "Disconnected").

My fix was very simple - update the `Last Activity` attribute immediately, right when the first activity has been received.
I've confirmed that it fixes the problem (for me at least), and now the devices that were previously "Disconnected" are now appearing as "Connected".

I hope that more people would enjoy this bugfix and would be able to use this great integration again.