### PR TITLE
Fix 'TOTAL_INCREASING' in home_assistant.py

### DIFF
--- a/custom_components/edgeos/component/managers/home_assistant.py
+++ b/custom_components/edgeos/component/managers/home_assistant.py
@@ -1200,12 +1200,12 @@ class EdgeOSHomeAssistantManager(HomeAssistantManager):
             if entity_suffix in STATS_DATA_RATE:
                 unit_of_measurement = UnitOfDataRate.BYTES_PER_SECOND
                 device_class = SensorDeviceClass.DATA_RATE
-                state_class = SensorStateClass.TOTAL_INCREASING
 
             elif entity_suffix in STATS_DATA_SIZE:
                 unit_of_measurement = UnitOfInformation.BYTES
                 device_class = SensorDeviceClass.DATA_SIZE
-
+                state_class = SensorStateClass.TOTAL_INCREASING
+                
             else:
                 unit_of_measurement = str(STATS_UNITS.get(entity_suffix)).capitalize()
 


### PR DESCRIPTION
Sensors of device class 'DATA_RATE' should be state class 'MEASUREMENT' while those of device class 'DATA_SIZE' should be state class 'TOTAL' or 'TOTAL_INCREASING'.

This change seems to be working for me for several days now. I'm not sure if additional changes are needed for the 'PACKETS' fields.