### PR TITLE
Remove `Last Activity` from device attributes

### DIFF
--- a/custom_components/edgeos/component/managers/home_assistant.py
+++ b/custom_components/edgeos/component/managers/home_assistant.py
@@ -1107,7 +1107,6 @@ class EdgeOSHomeAssistantManager(HomeAssistantManager):
 
             attributes = {
                 ATTR_FRIENDLY_NAME: entity_name,
-                LAST_ACTIVITY: device.last_activity_in_seconds,
             }
 
             unique_id = EntityData.generate_unique_id(


### PR DESCRIPTION
Fixes https://github.com/elad-bar/ha-edgeos/issues/104