### PR TITLE
[Feature/ Breaking Change] Make Leased Attribute a dict object

### DIFF
--- a/custom_components/edgeos/component/managers/home_assistant.py
+++ b/custom_components/edgeos/component/managers/home_assistant.py
@@ -885,13 +885,13 @@ class EdgeOSHomeAssistantManager(HomeAssistantManager):
         try:
             state = self._system.leased_devices
 
-            leased_devices = []
+            leased_devices = {}
 
             for unique_id in self._devices:
                 device = self._devices.get(unique_id)
 
                 if device.is_leased:
-                    leased_devices.append(f"{device.hostname} ({device.ip})")
+                    leased_devices[device.ip] = { "name": device.hostname, "MAC": device.mac }
 
             attributes = {
                 ATTR_FRIENDLY_NAME: entity_name,


### PR DESCRIPTION
### Changes

This change makes the leased attribute of unknown devices a dict of dict object.

The schema of each item is:
```yaml
[ip]: 
  hostname: [name]
  MAC: [MAC address]
```

### Rationale

This allows [my blueprint which fires a notification](https://github.com/illuzn/homeassistant-edgeos-notification) upon an unknown device connecting to function. Unknown is defined by a list of predefined known MAC addresses.

### Breaking Change

This is a breaking change because it changes the previous leased format of `[name] [ip]`. However:

* without specifying MAC addresses there it was probably of little utility to have this sensor.
* processing as a string is prone to problems e.g. if the name includes a "." character.

