### PR TITLE
Fix 2 bugs with Unknown Devices Sensor

### DIFF
--- a/custom_components/edgeos/data_processors/device_processor.py
+++ b/custom_components/edgeos/data_processors/device_processor.py
@@ -93,6 +93,10 @@ class DeviceProcessor(BaseProcessor):
             system_section = self._api_data.get(API_DATA_SYSTEM, {})
             service = system_section.get(DATA_SYSTEM_SERVICE, {})
 
+            if len(self._devices.keys()) != 0:
+                for existing_device in self._devices:
+                    self._devices.get(existing_device).is_leased = False
+
             dhcp_server = service.get(DATA_SYSTEM_SERVICE_DHCP_SERVER, {})
             shared_network_names = dhcp_server.get(DHCP_SERVER_SHARED_NETWORK_NAME, {})
 
@@ -148,6 +152,12 @@ class DeviceProcessor(BaseProcessor):
             data_leases = self._api_data.get(API_DATA_DHCP_LEASES, {})
             data_server_leases = data_leases.get(DHCP_SERVER_LEASES, {})
 
+            if len(self._devices.keys()) != 0:
+                for existing_device in self._devices:
+                    existing_device_data = self._devices.get(existing_device)
+                    existing_device_data.is_leased = False
+                    self._devices[existing_device_data.unique_id] = existing_device_data
+
             for subnet in data_server_leases:
                 subnet_data = data_server_leases.get(subnet, {})
 
@@ -202,6 +212,7 @@ class DeviceProcessor(BaseProcessor):
 
         else:
             device_data = existing_device_data
+            existing_device_data.is_leased = True
 
         self._devices[device_data.unique_id] = device_data
         self._devices_ip_mapping[device_data.ip] = device_data.unique_id

--- a/custom_components/edgeos/managers/coordinator.py
+++ b/custom_components/edgeos/managers/coordinator.py
@@ -533,7 +533,7 @@ class Coordinator(DataUpdateCoordinator):
 
         result = {
             ATTR_STATE: len(leased_devices.keys()),
-            ATTR_ATTRIBUTES: DHCP_SERVER_LEASED: leased_devices,
+            ATTR_ATTRIBUTES: { DHCP_SERVER_LEASED: leased_devices },
         }
 
         return result

--- a/custom_components/edgeos/managers/coordinator.py
+++ b/custom_components/edgeos/managers/coordinator.py
@@ -29,6 +29,7 @@ from ..common.consts import (
     ATTR_HOSTNAME,
     ATTR_IS_ON,
     ATTR_LAST_ACTIVITY,
+    DHCP_SERVER_LEASED,
     DOMAIN,
     ENTITY_CONFIG_ENTRY_ID,
     HA_NAME,
@@ -65,11 +66,14 @@ class Coordinator(DataUpdateCoordinator):
     _websockets: WebSockets | None
     _processors: dict[DeviceTypes, BaseProcessor] | None = None
 
-    _data_mapping: dict[
-        str,
-        Callable[[IntegrationEntityDescription], dict | None]
-        | Callable[[IntegrationEntityDescription, str], dict | None],
-    ] | None
+    _data_mapping: (
+        dict[
+            str,
+            Callable[[IntegrationEntityDescription], dict | None]
+            | Callable[[IntegrationEntityDescription, str], dict | None],
+        ]
+        | None
+    )
     _system_status_details: dict | None
 
     _last_update: float
@@ -529,7 +533,7 @@ class Coordinator(DataUpdateCoordinator):
 
         result = {
             ATTR_STATE: len(leased_devices.keys()),
-            ATTR_ATTRIBUTES: leased_devices,
+            ATTR_ATTRIBUTES: DHCP_SERVER_LEASED: leased_devices,
         }
 
         return result


### PR DESCRIPTION
Addresses issues #154 and #153.

### Unknown Devices Logic

https://github.com/illuzn/ha-edgeos/blob/cc9678c575eea992d070038aa6cb4d0e7ec94a2a/custom_components/edgeos/data_processors/device_processor.py#L146-L208

The `_update_leased_devices` and `_set_devices` logic was incorrect.
When a device first connects (or the integration is loaded), it will be added to the `_devices` variable as connected. For all such existing devices, the `is_leased` attribute does not change e.g. if it disconnects then `_set_devices` is not called and it remains in the list of `_devices` with `is_leased` set to True.

This corrects that logic by:
1. When `_update_leased_devices` is called, all `_devices` set `is_leased` to False.
2. When `set_devices` is called:
    (a) if it is a new device it is added as normal; or
    (b) if it is an existing *known* device (e.g. a device connects, disconnects then reconnects some time later), the existing data is used with `is_leased` set to true.

I considered the possibility to simply delete the entirety of `_devices` using for example clear() but decided against it since that might give rise to further issues.

### Unknown devices leased attribute
During the refactor, the dict `leased_devices` was erroneously written directly to attributes instead of under the subkey leased (which corresponds to the CONST `DHCP_SERVER_LEASED`) .