### PR TITLE
Make unknown_devices.attributes.leased a dict

### DIFF
--- a/custom_components/edgeos/data_processors/device_processor.py
+++ b/custom_components/edgeos/data_processors/device_processor.py
@@ -168,12 +168,8 @@ class DeviceProcessor(BaseProcessor):
             for device_mac in self._devices:
                 device = self._devices.get(device_mac)
                 if device.is_leased:
-                    device_name = device.mac
-
-                    if device.hostname not in ["", "?"]:
-                        device_name = f"{device.mac} ({device.hostname})"
-
-                    self._leased_devices[device.ip] = device_name
+                    device_dict = dict(mac=device.mac, hostname=device.hostname)
+                    self._leased_devices[device.ip] = device_dict
 
         except Exception as ex:
             exc_type, exc_obj, tb = sys.exc_info()


### PR DESCRIPTION
This makes each item in unknown_devices.attributes.leased a dict (i.e. a dict of dicts).

For example

```yaml
leased:
  192.168.1.2:
    mac: aa:bb:cc:dd:ee:ff
    hostname: abcdef
  192.168.1.3:
    mac: 11:22:33:44:55:66
    hostname: 123456
```

This makes processing this attribute far easier in Home Assistant for example in my [unknown devices blueprint](https://github.com/illuzn/homeassistant-edgeos-notification) which generates a notification when an unknown device connects.

Technically, this is a breaking change but it the behaviour was broken by an undocumented change during the refactor anyway - from `192.168.1.2: aa:bb:cc:dd:ee:ff (?)` to `192.168.1.2: aa:bb:cc:dd:ee:ff` 